### PR TITLE
Add -s option to the grep command

### DIFF
--- a/ocf/nova-api
+++ b/ocf/nova-api
@@ -200,7 +200,7 @@ nova_api_monitor() {
         ocf_log warn "$OCF_RESKEY_monitor_binary missing, can not monitor!" 
     else
         # Check ec2, osapi_compute, osapi_volume and metadata ports
-        API_LIST_CHECK=`"$OCF_RESKEY_monitor_binary" -a | egrep -E "\"$OCF_RESKEY_api_listened_port\"" | grep -q "LISTEN"`
+        API_LIST_CHECK=`"$OCF_RESKEY_monitor_binary" -a | egrep -E "\"$OCF_RESKEY_api_listened_port\"" | grep -sq "LISTEN"`
     fi
     rc=$?
     if [ $rc -ne 0 ]; then


### PR DESCRIPTION
Add -s option to the grep command to suppress error message from the grep output
