### PR TITLE
L3 Agent Shutdown should not kill dnsmasq instances

### DIFF
--- a/ocf/quantum-agent-l3
+++ b/ocf/quantum-agent-l3
@@ -274,7 +274,6 @@ quantum_l3_agent_stop() {
 
     # Try SIGTERM
     pid=`cat $OCF_RESKEY_pid`
-    pid="$pid `ps ax | grep -v grep | grep 'dnsmasq' | cut -c1-5`"
     ocf_run kill -s TERM $pid
     rc=$?
     if [ $rc -ne 0 ]; then


### PR DESCRIPTION
The dnsmasq instances are managed by the quantum-dhcp-agent so
killing then make no sense and creates races in stop when both
services are running on the same node.
