### PR TITLE
edit monitor to check for rabbit connection

### DIFF
--- a/ocf/neutron-agent-l3
+++ b/ocf/neutron-agent-l3
@@ -218,7 +218,7 @@ neutron_l3_agent_monitor() {
     # We are sure to hit the scheduler process and not other Neutron process with the same connection behavior (for example neutron-server)
         pid=`cat $OCF_RESKEY_pid`
         # check the connections according to the PID
-        network_amqp_check=`netstat -punt | grep -s "$OCF_RESKEY_rebbit_server_port" | grep -s "$pid" | grep -qs "ESTABLISHED"`
+        network_amqp_check=`netstat -punt | grep -s "$OCF_RESKEY_rabbit_server_port" | grep -s "$pid" | grep -qs "ESTABLISHED"`
         rc=$?
 	    if [ $rc -ne 0 ]; then
 	        ocf_log err "Neutron L3 Server is not connected to the RabbitMQ server: $rc"

--- a/ocf/neutron-agent-l3
+++ b/ocf/neutron-agent-l3
@@ -38,6 +38,7 @@ OCF_RESKEY_plugin_config_default="/etc/neutron/l3_agent.ini"
 OCF_RESKEY_user_default="neutron"
 OCF_RESKEY_pid_default="$HA_RSCTMP/$OCF_RESOURCE_INSTANCE.pid"
 OCF_RESKEY_neutron_server_port_default="9696"
+OCF_RESKEY_rabbit_server_port_default="5672"
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 : ${OCF_RESKEY_config=${OCF_RESKEY_config_default}}
@@ -217,10 +218,10 @@ neutron_l3_agent_monitor() {
     # We are sure to hit the scheduler process and not other Neutron process with the same connection behavior (for example neutron-server)
         pid=`cat $OCF_RESKEY_pid`
         # check the connections according to the PID
-        network_amqp_check=`netstat -punt | grep -s "$OCF_RESKEY_neutron_server_port" | grep -s "$pid" | grep -qs "ESTABLISHED"`
+        network_amqp_check=`netstat -punt | grep -s "$OCF_RESKEY_rebbit_server_port" | grep -s "$pid" | grep -qs "ESTABLISHED"`
         rc=$?
 	    if [ $rc -ne 0 ]; then
-	        ocf_log err "Neutron L3 Server is not connected to the Neutron server: $rc"
+	        ocf_log err "Neutron L3 Server is not connected to the RabbitMQ server: $rc"
 	        return $OCF_NOT_RUNNING
 	    fi
 


### PR DESCRIPTION
Previously the neutron_l3_agent_monitor block checked for an established network connection to the neutron-server port.  In our environment we use RabbitMQ and there is no connection to neutron-server, but there is a connection to RabbitMQ.