### PR TITLE
Update neutron-agent-dhcp

### DIFF
--- a/ocf/neutron-agent-dhcp
+++ b/ocf/neutron-agent-dhcp
@@ -95,7 +95,7 @@ Location of the OpenStack Neutron Service (neutron-server) configuration file
 <content type="string" default="${OCF_RESKEY_config_default}" />
 </parameter>
 
-<parameter name="plugin config" unique="0" required="0">
+<parameter name="plugin_config" unique="0" required="0">
 <longdesc lang="en">
 Location of the OpenStack DHCP Service (neutron-dhcp-agent) configuration file
 </longdesc>


### PR DESCRIPTION
Adds an underscore to plugin_config parameter name to fix OpenStack upstream doc bug 1316006.
